### PR TITLE
Spawner FSM to Allow Delays between Waves Updated

### DIFF
--- a/include/EnemySpawner.hpp
+++ b/include/EnemySpawner.hpp
@@ -23,10 +23,8 @@ enum class WaveState {
 class EnemySpawner {
 public:
     EnemySpawner(unsigned int screenWidth);
-    EnemySpawner(float spawnInterval, unsigned int screenWidth);    // legacy UNUSED
     
     void update(std::vector<std::unique_ptr<Enemy>>& enemies);
-    void startNextWave(); // legacy
     void reset();
     void startSpawn();
     bool isWaveComplete() const;
@@ -41,7 +39,6 @@ private:
     int enemiesSpawnedInWave = 0;
     bool waveComplete = false;
     bool allWavesComplete = false;
-    float spawnInterval = 0;    // legacy UNUSED
     float waveDelayDuration = 0.f;
     sf::Clock spawnClock;
     sf::Clock waveDelayClock;

--- a/src/EnemySpawner.cpp
+++ b/src/EnemySpawner.cpp
@@ -6,10 +6,6 @@
 #include "Message.hpp"
 
 
-//Legacy UNUSED
-EnemySpawner::EnemySpawner(float spawnInterval, unsigned int screenWidth)
-    : spawnInterval(spawnInterval), screenWidth(screenWidth) {}
-
 EnemySpawner::EnemySpawner(unsigned int screenWidth)
     : screenWidth(screenWidth), currentWaveIndex(-1), enemiesSpawnedInWave(0),
       waveComplete(false), allWavesComplete(false), waveDelayDuration(0.f), waveState(WaveState::Idle) {
@@ -28,14 +24,6 @@ void EnemySpawner::reset()
     waveState = WaveState::Idle;
 
     postMessage("[WaveSpawner] Waves reset."); // TODO: add DEBUG MESSAGE in game
-}
-
-//LEGACY for author's minimal reference only, DO NOT USE
-void EnemySpawner::startNextWave() 
-{
-    currentWaveIndex++;
-    enemiesSpawnedInWave = 0;
-    waveComplete = false;
 }
 
 void EnemySpawner::startSpawn()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,11 +83,7 @@ int main()
     sf::Clock clock;
     sf::Clock fireCooldownClock; 
 
-    WaveState waveState = WaveState::Idle;
-    sf::Clock waveDelayClock;
-    float waveDelayDuration = 0.f;
-    bool waitingForPlayerToStartWave = true;
-
+    bool waitingForPlayerToStartSpawningEnemies = true;
 
     while (window.isOpen())
     {
@@ -116,7 +112,7 @@ int main()
             bullets.clear();
             enemies.clear();
             spawner.reset();
-            waitingForPlayerToStartWave = true;
+            waitingForPlayerToStartSpawningEnemies = true;
         }
         
         
@@ -128,9 +124,9 @@ int main()
         messageManager.update();
                 
         // Spawn
-        if (waitingForPlayerToStartWave && sf::Keyboard::isKeyPressed(sf::Keyboard::Key::Enter)) {
+        if (waitingForPlayerToStartSpawningEnemies && sf::Keyboard::isKeyPressed(sf::Keyboard::Key::Enter)) {
             spawner.startSpawn();
-            waitingForPlayerToStartWave = false;
+            waitingForPlayerToStartSpawningEnemies = false;
         }
 
         // Collision detection (bullets vs enemies)


### PR DESCRIPTION
Edited Spawner update FSM to allow for delays to exist between waves.

remove legacy in spawner, remove unused variables in main. Change waitingForPlayerToStartWave to ...StartSpawn.